### PR TITLE
File controller: adding name parameter and tests

### DIFF
--- a/src/main/java/callhub/connect/controllers/FileController.java
+++ b/src/main/java/callhub/connect/controllers/FileController.java
@@ -27,7 +27,7 @@ public class FileController {
     HttpHeaders headers = new HttpHeaders();
     DataAccess dataAccessObject;
     @GetMapping("/upload_local")
-    public ResponseEntity<String> uploadPDFLocal () {
+    public ResponseEntity<String> uploadPDFLocal(@RequestParam("name") String name) {
         String currentDirectory = System.getProperty("user.dir");
         String pathName = currentDirectory + "/src/main/java/callhub/connect/pdfs/fall2023.pdf";
         FileDocument result;
@@ -41,18 +41,18 @@ public class FileController {
         } catch (IOException e) {
             return new ResponseEntity<>(e.getMessage(), headers, HttpStatus.BAD_REQUEST);
         }
-        result = documentRepository.save(new FileDocument("timetable", data, LocalDate.now()));
+        result = documentRepository.save(new FileDocument(name, data, LocalDate.now()));
         return new ResponseEntity<>("Uploaded! " + result.getId(), headers, HttpStatus.OK);
     }
 
     @PostMapping("/upload_network")
-    public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file) {
+    public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file, @RequestParam("name") String name) {
         dataAccessObject = new NetworkDataAccess(file);
         FileDocument result;
         Binary data;
         try {
             data = dataAccessObject.serializePDF();
-            result = documentRepository.save(new FileDocument("timetable", data, LocalDate.now()));
+            result = documentRepository.save(new FileDocument(name, data, LocalDate.now()));
             return new ResponseEntity<>(result.getId(), headers, HttpStatus.OK);
         } catch (IOException e) {
             return new ResponseEntity<>(e.getMessage(), headers, HttpStatus.BAD_REQUEST);

--- a/src/test/java/callhub/connect/controllers/FileControllerTests.java
+++ b/src/test/java/callhub/connect/controllers/FileControllerTests.java
@@ -1,0 +1,81 @@
+package callhub.connect.controllers;
+
+import callhub.connect.data_access.DataAccess;
+import callhub.connect.data_access.DocumentRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMultipartHttpServletRequestDsl;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FileControllerTests {
+    @MockBean
+    public DocumentRepository documentRepository;
+    HttpHeaders headers = new HttpHeaders();
+    DataAccess dataAccessObject;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void testUploadPDFLocal() {
+    }
+
+    @Test // Cannot invoke "callhub.connect.entities.FileDocument.getId()" because "result" is null
+    void testUploadFile_Mock() throws Exception {
+        MockMultipartFile sampleFile = new MockMultipartFile(
+                "file",
+                "sample-file-mock.pdf",
+                "application/pdf",
+                "This is the file content".getBytes());
+
+        MockMultipartHttpServletRequestBuilder multipartRequest =
+                MockMvcRequestBuilders.multipart("/files/upload_network");
+        mockMvc.perform(multipartRequest.file(sampleFile).param("name", "test")).andExpect(status().isOk());
+    }
+
+    @Test
+    void testUploadFile_Fall2023() throws Exception {
+        String currentDirectory = System.getProperty("user.dir");
+        String pathName = currentDirectory + "/src/main/java/callhub/connect/pdfs/fall2023.pdf";
+        File pdfFile = new File(pathName);
+        MockMultipartFile sampleFile = new MockMultipartFile(
+                "file",
+                pdfFile.getName(),
+                "application/pdf",
+                new FileInputStream(pdfFile));
+
+        MockMultipartHttpServletRequestBuilder multipartRequest =
+                MockMvcRequestBuilders.multipart("/files/upload_network");
+        mockMvc.perform(multipartRequest.file(sampleFile).param("name", "test")).andExpect(status().isOk());
+    }
+
+    @Test
+    void testUploadFile_NoFile() throws Exception {
+        MockMultipartHttpServletRequestBuilder multipartRequest =
+                MockMvcRequestBuilders.multipart("/files/upload_network");
+        mockMvc.perform(multipartRequest).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testFindDocumentByID() {
+    }
+}

--- a/src/test/java/callhub/connect/controllers/FileControllerTests.java
+++ b/src/test/java/callhub/connect/controllers/FileControllerTests.java
@@ -1,27 +1,29 @@
 package callhub.connect.controllers;
 
-import callhub.connect.data_access.DataAccess;
 import callhub.connect.data_access.DocumentRepository;
+import callhub.connect.entities.FileDocument;
+import org.bson.types.Binary;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MockMultipartHttpServletRequestDsl;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.time.LocalDate;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -29,17 +31,28 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class FileControllerTests {
     @MockBean
     public DocumentRepository documentRepository;
-    HttpHeaders headers = new HttpHeaders();
-    DataAccess dataAccessObject;
 
     @Autowired
     MockMvc mockMvc;
 
     @Test
-    void testUploadPDFLocal() {
+    void testUploadPDFLocal() throws Exception {
+        when(documentRepository.save(any())).thenReturn(new FileDocument(
+                "test123",
+                new Binary("sample file content".getBytes()),
+                LocalDate.now()));
+
+        RequestBuilder request = get("/files/upload_local?name=test123");
+        mockMvc.perform(request).andExpect(status().isOk());
     }
 
-    @Test // Cannot invoke "callhub.connect.entities.FileDocument.getId()" because "result" is null
+    @Test
+    void testUploadPDFLocal_NoName() throws Exception {
+        RequestBuilder request = get("/files/upload_local");
+        mockMvc.perform(request).andExpect(status().isBadRequest());
+    }
+
+    @Test
     void testUploadFile_Mock() throws Exception {
         MockMultipartFile sampleFile = new MockMultipartFile(
                 "file",
@@ -47,9 +60,15 @@ class FileControllerTests {
                 "application/pdf",
                 "This is the file content".getBytes());
 
+        // documentRepository is a mock, not real, so we need to mock the save() method - by default it returns null
+        when(documentRepository.save(any())).thenReturn(new FileDocument(
+                "MockFile",
+                new Binary("This is the file content".getBytes()),
+                LocalDate.now()));
+
         MockMultipartHttpServletRequestBuilder multipartRequest =
                 MockMvcRequestBuilders.multipart("/files/upload_network");
-        mockMvc.perform(multipartRequest.file(sampleFile).param("name", "test")).andExpect(status().isOk());
+        mockMvc.perform(multipartRequest.file(sampleFile).param("name", "MockFile")).andExpect(status().isOk());
     }
 
     @Test
@@ -63,9 +82,14 @@ class FileControllerTests {
                 "application/pdf",
                 new FileInputStream(pdfFile));
 
+        when(documentRepository.save(any())).thenReturn(new FileDocument(
+                "MockFile",
+                new Binary("sample pdf content".getBytes()),
+                LocalDate.now()));
+
         MockMultipartHttpServletRequestBuilder multipartRequest =
                 MockMvcRequestBuilders.multipart("/files/upload_network");
-        mockMvc.perform(multipartRequest.file(sampleFile).param("name", "test")).andExpect(status().isOk());
+        mockMvc.perform(multipartRequest.file(sampleFile).param("name", "Fall2023")).andExpect(status().isOk());
     }
 
     @Test
@@ -75,7 +99,26 @@ class FileControllerTests {
         mockMvc.perform(multipartRequest).andExpect(status().isBadRequest());
     }
 
+// ONLY WORKS IF ID IS SET PUBLIC...
+//
+//    @Test
+//    void testFindDocumentByID() throws Exception {
+//        FileDocument fileDocument = new FileDocument(
+//                "MockFile",
+//                new Binary("This is the file content".getBytes()),
+//                LocalDate.now());
+//
+//        fileDocument.id = "123314";
+//
+//        when(documentRepository.findById(any())).thenReturn(Optional.of(fileDocument));
+//
+//        RequestBuilder request = get("/files/{id}", fileDocument.id);
+//        mockMvc.perform(request).andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_PDF_VALUE));
+//    }
+
     @Test
-    void testFindDocumentByID() {
+    void testFindDocumentByID_InvalidID() throws Exception {
+        RequestBuilder request = get("/files/12345678");
+        mockMvc.perform(request).andExpect(status().isBadRequest()).andExpect(content().string("File could not be found."));
     }
 }


### PR DESCRIPTION
- added name parameter to upload_local and upload_network endpoints (no longer hard coded to “timetable”)
- wrote tests for FileController using Mockito 

the test for findDocumentByID only works if id is a public attribute or if we make a setId method…